### PR TITLE
Fix reference counting for skb pages

### DIFF
--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -972,12 +972,6 @@ static inline struct sk_buff *alloc_skb_fclone(unsigned int size,
 	return __alloc_skb(size, priority, SKB_ALLOC_FCLONE, NUMA_NO_NODE);
 }
 
-struct sk_buff *__alloc_skb_head(gfp_t priority, int node);
-static inline struct sk_buff *alloc_skb_head(gfp_t priority)
-{
-	return __alloc_skb_head(priority, -1);
-}
-
 struct sk_buff *skb_morph(struct sk_buff *dst, struct sk_buff *src);
 int skb_copy_ubufs(struct sk_buff *skb, gfp_t gfp_mask);
 struct sk_buff *skb_clone(struct sk_buff *skb, gfp_t priority);

--- a/net/core/sock.c
+++ b/net/core/sock.c
@@ -1642,8 +1642,16 @@ void sock_wfree(struct sk_buff *skb)
 	 * if sk_wmem_alloc reaches 0, we must finish what sk_free()
 	 * could not do because of in-flight packets
 	 */
-	if (atomic_sub_and_test(len, &sk->sk_wmem_alloc))
+	if (atomic_sub_and_test(len, &sk->sk_wmem_alloc)) {
+		/*
+		 * We don't bother with Tempesta socket memory limitations
+		 * since in proxy mode we just forward packets instead of real
+		 * allocations. Probably this is an issue. Probably sockets
+		 * can be freed from under us.
+		 */
+		WARN_ON(sock_flag(sk, SOCK_TEMPESTA));
 		__sk_free(sk);
+	}
 }
 EXPORT_SYMBOL(sock_wfree);
 

--- a/net/ipv4/tcp.c
+++ b/net/ipv4/tcp.c
@@ -613,7 +613,11 @@ void skb_entail(struct sock *sk, struct sk_buff *skb)
 	tcb->seq     = tcb->end_seq = tp->write_seq;
 	tcb->tcp_flags = TCPHDR_ACK;
 	tcb->sacked  = 0;
-	__skb_header_release(skb);
+	/*
+	 * fclones are possible here, so accurately update
+	 * skb_shinfo(skb)->dataref.
+	 */
+	skb_header_release(skb);
 	tcp_add_write_queue_tail(sk, skb);
 	sk->sk_wmem_queued += skb->truesize;
 	sk_mem_charge(sk, skb->truesize);


### PR DESCRIPTION
1. Fix #692: properly free fclone'd skb and update skb_shinfo(skb)->dataref in skb_entail()
   (see https://github.com/tempesta-tech/tempesta/issues/692#issuecomment-354204275);

2. Fix skb_morph(), pskb_carve_inside_header() and pskb_carve_inside_nonlinear()
   operations with skb pages - probably fixes #615;

3. Optimize inet_csk_reqsk_queue_add(): move Tempesta's fast path frum under the lock;

4. Remove unused alloc_skb_head() (also done in recent kernels);