### PR TITLE
get_proto_family() is called by ss_sock_create() under rcu_read_lock_…

### DIFF
--- a/net/socket.c
+++ b/net/socket.c
@@ -164,7 +164,7 @@ static const struct net_proto_family __rcu *net_families[NPROTO] __read_mostly;
 
 const struct net_proto_family *get_proto_family(int family)
 {
-	return rcu_dereference(net_families[family]);
+	return rcu_dereference_bh(net_families[family]);
 }
 EXPORT_SYMBOL(get_proto_family);
 


### PR DESCRIPTION
…bh(), so do proper dereferencing