### PR TITLE
Fix https://github.com/tempesta-tech/tempesta/issues/926

### DIFF
--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -1417,9 +1417,9 @@ EXPORT_SYMBOL(__pskb_copy_fclone);
 int pskb_expand_head(struct sk_buff *skb, int nhead, int ntail,
 		     gfp_t gfp_mask)
 {
-	int i;
+	int i, osize = skb_end_offset(skb);
 	u8 *data;
-	int size = nhead + skb_end_offset(skb) + ntail;
+	int size = osize + nhead + ntail;
 	long off;
 
 	BUG_ON(nhead < 0);
@@ -1494,6 +1494,10 @@ int pskb_expand_head(struct sk_buff *skb, int nhead, int ntail,
 	skb->hdr_len  = 0;
 	skb->nohdr    = 0;
 	atomic_set(&skb_shinfo(skb)->dataref, 1);
+
+	if (!skb->sk || skb->destructor == sock_edemux)
+		skb->truesize += size - osize;
+
 	return 0;
 
 nofrags:

--- a/net/netlink/af_netlink.c
+++ b/net/netlink/af_netlink.c
@@ -1210,8 +1210,7 @@ static struct sk_buff *netlink_trim(struct sk_buff *skb, gfp_t allocation)
 		skb = nskb;
 	}
 
-	if (!pskb_expand_head(skb, 0, -delta, allocation))
-		skb->truesize -= delta;
+	pskb_expand_head(skb, 0, -delta, allocation);
 
 	return skb;
 }

--- a/net/wireless/util.c
+++ b/net/wireless/util.c
@@ -620,8 +620,6 @@ int ieee80211_data_from_8023(struct sk_buff *skb, const u8 *addr,
 
 		if (pskb_expand_head(skb, head_need, 0, GFP_ATOMIC))
 			return -ENOMEM;
-
-		skb->truesize += head_need;
 	}
 
 	if (encaps_data) {


### PR DESCRIPTION
The problem is in the mainline kernel, so the patch https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git/commit/?id=158f323b9868b59967ad96957c4ca388161be321 is ported. However, the patch doesn't update sk_wmem_queued after update of skb->truesize, so the second part of the patch is about correct update of sk_wmem_queued. This part is almost copy@paste from tcp_trim_head() which gets delta_truesize from __pskb_trim_head() and update sk_wmem_queued.

I had just a quick look onto current version of the Linux kernel and it seems the socket wmem accounting isn't updated as in our version. However, since the bug has been seen for Tempesta generated skbs only, probably it doesn't affect native Linux workflow.